### PR TITLE
Amplía de decoradores a decoradores parametrizados

### DIFF
--- a/alumni/y4izus/param_decorators.py
+++ b/alumni/y4izus/param_decorators.py
@@ -3,6 +3,7 @@ from functools import wraps
 
 def log_parameters(label):
     def _decorator(target):
+        @wraps(target)
         def _decorated(*args, **kwargs):
             print(f"[{label}] Called with {args} and {kwargs}")
             return target(*args, **kwargs)

--- a/alumni/y4izus/param_decorators.py
+++ b/alumni/y4izus/param_decorators.py
@@ -42,7 +42,7 @@ def log(label):
 def solve(a, b, c):
     """Solves a quadratic equation given the coefficients."""
     root = (b ** 2 - 4 * a * c) ** 1 / 2
-    return (b + root) / 2 * a, (b - root) / 2 * a
+    return (-b + root) / 2 * a, (-b - root) / 2 * a
 
 
 solve(4, 2, 1)

--- a/alumni/y4izus/param_decorators.py
+++ b/alumni/y4izus/param_decorators.py
@@ -1,0 +1,48 @@
+from functools import wraps
+
+
+def log_parameters(label):
+    def _decorator(target):
+        def _decorated(*args, **kwargs):
+            print(f"[{label}] Called with {args} and {kwargs}")
+            return target(*args, **kwargs)
+
+        return _decorated
+
+    return _decorator
+
+
+def log_return(label):
+    def _decorator(target):
+        @wraps(target)
+        def _decorated(*args, **kwargs):
+            result = target(*args, **kwargs)
+            print(f"[{label}] Returned {result}")
+            return result
+
+        return _decorated
+
+    return _decorator
+
+
+def log(label):
+    def _decorator(target):
+        @log_parameters(label)
+        @log_return(label)
+        def _decorated(*args, **kwargs):
+            return target(*args, **kwargs)
+
+        return _decorated
+
+    return _decorator
+
+
+@log("XXX")
+def solve(a, b, c):
+    """Solves a quadratic equation given the coefficients."""
+    root = (b ** 2 - 4 * a * c) ** 1 / 2
+    return (b + root) / 2 * a, (b - root) / 2 * a
+
+
+solve(4, 2, 1)
+solve(16, 25, c=5)

--- a/alumni/y4izus/param_decorators.py
+++ b/alumni/y4izus/param_decorators.py
@@ -29,6 +29,7 @@ def log(label):
     def _decorator(target):
         @log_parameters(label)
         @log_return(label)
+        @wraps(target)
         def _decorated(*args, **kwargs):
             return target(*args, **kwargs)
 


### PR DESCRIPTION
Reimplementa `log`, `log_parameters` y `log_return` como decoradores parametrizados de manera que se obtiene el mismo resultado que con el `log` parametrizado